### PR TITLE
Terminate actor system when done

### DIFF
--- a/src/main/scala/com/gu/tip/PathReader.scala
+++ b/src/main/scala/com/gu/tip/PathReader.scala
@@ -42,6 +42,7 @@ case object NumberOfPaths                           extends PathsActorMessage
 case class NumberOfPathsAnswer(value: Int)          extends PathsActorMessage
 case object NumberOfVerifiedPaths                   extends PathsActorMessage
 case class NumberOfVerifiedPathsAnswer(value: Int)  extends PathsActorMessage
+case object Stop                                    extends PathsActorMessage
 
 // NOK
 case class PathDoesNotExist(pathName: String)       extends PathsActorMessage
@@ -85,6 +86,10 @@ class PathsActor(val paths: Map[String, EnrichedPath]) extends Actor with LazyLo
     case NumberOfPaths => sender() ! NumberOfPathsAnswer(paths.size)
 
     case NumberOfVerifiedPaths => sender() ! NumberOfVerifiedPathsAnswer(paths.size - _unverifiedPathCount)
+
+    case Stop =>
+      logger.info("Terminating Actor System...")
+      context.system.terminate()
   }
 }
 


### PR DESCRIPTION
When all paths have been verified `Tip` asks `PathsActor` to terminate the actor system.

If a message is sent to `PathsActor` after termination, then the following exceptions is thrown:

```
akka.pattern.AskTimeoutException: Recipient[Actor[akka://default/user/$a#-2137276030]] had already been terminated. Sender[null] sent the message of type "com.gu.tip.Verify".
```

We handle this exceptions and simply return `TipFinished`.

This should do for now, but we should investigate a cleaner way of checking if the actor system is shutdown.

After verifying all paths and letting the system run for 4 minutes there does not seem to be any thread resource leaks:

<img width="1404" alt="screen shot 2017-04-12 at 13 55 32" src="https://cloud.githubusercontent.com/assets/13835317/24958621/d6639f50-1f87-11e7-9bb5-135e056c42a9.png">
