### PR TITLE
Replace Task with IO effect

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val http4sVersion = "0.17.6"
+  val http4sVersion = "0.18.0-M7"
   val akkaVersion = "2.5.8"
 
   lazy val scalaTest =      "org.scalatest"               %%  "scalatest"           % "3.0.4"         % Test

--- a/src/main/scala/com/gu/tip/GitHubApi.scala
+++ b/src/main/scala/com/gu/tip/GitHubApi.scala
@@ -1,13 +1,13 @@
 package com.gu.tip
 
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Task
 import net.liftweb.json._
 import net.liftweb.json.DefaultFormats
 
 trait GitHubApiIf { this: HttpClientIf =>
-  def getLastMergeCommitMessage(): Task[String]
-  def setLabel(prNumber: String): Task[String]
+  def getLastMergeCommitMessage(): IO[String]
+  def setLabel(prNumber: String): IO[String]
 
   val githubApiRoot = "https://api.github.com"
 }
@@ -23,13 +23,13 @@ trait GitHubApi extends GitHubApiIf with LazyLogging { this: HttpClientIf =>
 
     So we try to pick out pull request number #118
   */
-  override def getLastMergeCommitMessage(): Task[String] = {
+  override def getLastMergeCommitMessage(): IO[String] = {
     get(s"$githubApiRoot/repos/$owner/$repo/commits/master", authHeader).map { responseBody =>
       (parse(responseBody) \ "commit" \ "message").extract[String]
     }
   }
 
-  override def setLabel(prNumber: String): Task[String] = {
+  override def setLabel(prNumber: String): IO[String] = {
     post(s"$githubApiRoot/repos/$owner/$repo/issues/$prNumber/labels", authHeader, s"""["$label"]""")
   }
 

--- a/src/main/scala/com/gu/tip/HttpClient.scala
+++ b/src/main/scala/com/gu/tip/HttpClient.scala
@@ -1,19 +1,19 @@
 package com.gu.tip
 
-import fs2.Task
-import org.http4s.client._
-import org.http4s.client.blaze._
+import cats.effect._
 import org.http4s._
-import org.http4s.dsl._
+import org.http4s.client.blaze.Http1Client
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.dsl.io._
 
 trait HttpClientIf {
-  def get(endpoint: String, authHeader: (String, String)): Task[String]
-  def post(endpoint: String, authHeader: (String, String), jsonBody: String): Task[String]
+  def get(endpoint: String, authHeader: (String, String)): IO[String]
+  def post(endpoint: String, authHeader: (String, String), jsonBody: String): IO[String]
 }
 
-trait HttpClient extends HttpClientIf {
-  override def get(endpoint: String, authHeader: (String, String)): Task[String] = {
-    val request = Request(
+trait HttpClient extends HttpClientIf with Http4sClientDsl[IO] {
+  override def get(endpoint: String, authHeader: (String, String)): IO[String] = {
+    val request = Request[IO](
       uri = Uri.unsafeFromString(endpoint),
       headers = Headers(Header(authHeader._1, authHeader._2)),
       method = Method.GET
@@ -21,10 +21,10 @@ trait HttpClient extends HttpClientIf {
     client.expect[String](request)
   }
 
-  override def post(endpoint: String, authHeader: (String, String), jsonBody: String): Task[String] = {
+  override def post(endpoint: String, authHeader: (String, String), jsonBody: String): IO[String] = {
     val request = POST(Uri.unsafeFromString(endpoint), jsonBody).putHeaders(Header(authHeader._1, authHeader._2))
     client.expect[String](request)
   }
 
-  private val client = PooledHttp1Client()
+  private val client = Http1Client[IO]().unsafeRunSync
 }

--- a/src/main/scala/com/gu/tip/Notifier.scala
+++ b/src/main/scala/com/gu/tip/Notifier.scala
@@ -1,14 +1,14 @@
 package com.gu.tip
 
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Task
 
 trait NotifierIf { this: GitHubApiIf =>
-  def setLabelOnLatestMergedPr(): Task[String]
+  def setLabelOnLatestMergedPr(): IO[String]
 }
 
 trait Notifier extends NotifierIf with LazyLogging { this: GitHubApiIf =>
-  def setLabelOnLatestMergedPr(): Task[String] =
+  def setLabelOnLatestMergedPr(): IO[String] =
     for {
       prNumber <- getLastMergedPullRequestNumber()
       responseBody <- setGitHubLabel(prNumber)
@@ -22,14 +22,14 @@ trait Notifier extends NotifierIf with LazyLogging { this: GitHubApiIf =>
 
     So we try to pick out pull request number #118
   */
-  private def getLastMergedPullRequestNumber(): Task[String] = {
+  private def getLastMergedPullRequestNumber(): IO[String] = {
     getLastMergeCommitMessage().map { message =>
       val prNumberPattern = """#\d+""".r
       prNumberPattern.findFirstIn(message).get.tail // Using get() because currently we just swallow any exception in Tip.verify()
     }
   }
 
-  private def setGitHubLabel(prNumber: String): Task[String] =
+  private def setGitHubLabel(prNumber: String): IO[String] =
     setLabel(prNumber).map { response =>
       logger.info(s"Successfully set verification label on PR $prNumber")
       response

--- a/src/test/scala/com/gu/tip/HttpClientTest.scala
+++ b/src/test/scala/com/gu/tip/HttpClientTest.scala
@@ -9,15 +9,16 @@ class HttpClientTest extends FlatSpec with MustMatchers {
   behavior of "HttpClient"
 
   it should "be able to make a GET request" in {
-    HttpClient.get("http://example.com", ("Authorization","test")).unsafeRun().map(_ => succeed)
+    HttpClient.get("http://example.com", ("Authorization","test"))
+      .attempt.map(_.fold(error => fail, _ => succeed)).unsafeRunSync()
   }
 
   it should "be able to make a POST request" in {
     HttpClient.post(
-      "http://petstore.swagger.io/v2/pet",
-      ("Authorization","test"),
-      "{\"name\": \"doggie\"}"
-    ).map(_ => succeed)
+      "https://duckduckgo.com",
+      ("",""),
+      "test body"
+    ).attempt.map(_.fold(error => fail, _ => succeed)).unsafeRunSync()
   }
 
 }


### PR DESCRIPTION
[IO](https://github.com/typelevel/cats-effect) is improved `fs2.Task`

* [An IO monad for cats](https://typelevel.org/blog/2017/05/02/io-monad-for-cats.html)
* [Decide the fate of Task](https://github.com/functional-streams-for-scala/fs2/issues/855)

http4s client with IO examples:
* [GET](http://http4s.org/v0.18/client/)
* [POST](https://github.com/http4s/http4s/blob/master/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientPostExample.scala)
