### PR TITLE
Add scalafmt code formatter

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+style = default
+align = true    # For pretty alignment.

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,9 @@ lazy val root = (project in file(".")).settings(
     releaseStepCommand("sonatypeReleaseAll"),
     pushChanges
   ),
-  (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value
+  (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value,
+  scalafmtTestOnCompile := true,
+  scalafmtShowDiff := true
 )
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")

--- a/build.sbt
+++ b/build.sbt
@@ -1,38 +1,35 @@
 import Dependencies._
 import sbtrelease.ReleaseStateTransformations._
 
-lazy val root = (project in file(".")).
-  settings(
-    name          := "tip",
-    description   := "Scala library for testing in production.",
-    organization  := "com.gu",
-    scalaVersion  := "2.12.4",
-    licenses      := Seq("GPLv3" -> url("http://www.gnu.org/licenses/gpl.html")),
-    scmInfo       := Some(ScmInfo(url("https://github.com/guardian/tip"), "scm:git:git@github.com:guardian/tip.git")),
-
-    libraryDependencies ++= dependencies,
-
-    crossScalaVersions ++= Seq("2.11.12"),
-    sources in doc in Compile := List(),
-
-    releaseCrossBuild := true,
-    releaseProcess := Seq[ReleaseStep](
-      checkSnapshotDependencies,
-      inquireVersions,
-      runClean,
-      runTest,
-      setReleaseVersion,
-      commitReleaseVersion,
-      tagRelease,
-      releaseStepCommand("publishSigned"),
-      setNextVersion,
-      commitNextVersion,
-      releaseStepCommand("sonatypeReleaseAll"),
-      pushChanges
-    ),
-
-    (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value
-  )
+lazy val root = (project in file(".")).settings(
+  name := "tip",
+  description := "Scala library for testing in production.",
+  organization := "com.gu",
+  scalaVersion := "2.12.4",
+  licenses := Seq("GPLv3" -> url("http://www.gnu.org/licenses/gpl.html")),
+  scmInfo := Some(
+    ScmInfo(url("https://github.com/guardian/tip"),
+            "scm:git:git@github.com:guardian/tip.git")),
+  libraryDependencies ++= dependencies,
+  crossScalaVersions ++= Seq("2.11.12"),
+  sources in doc in Compile := List(),
+  releaseCrossBuild := true,
+  releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest,
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    releaseStepCommand("publishSigned"),
+    setNextVersion,
+    commitNextVersion,
+    releaseStepCommand("sonatypeReleaseAll"),
+    pushChanges
+  ),
+  (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value
+)
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 compileScalastyle := scalastyle.in(Compile).toTask("").value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("org.xerial.sbt"           %   "sbt-sonatype"                % "2.0
 addSbtPlugin("org.scoverage"            %   "sbt-scoverage"               % "1.5.1")
 addSbtPlugin("org.scoverage"            %   "sbt-coveralls"               % "1.2.2")
 addSbtPlugin("org.scalastyle"           %%  "scalastyle-sbt-plugin"       % "1.0.0")
+addSbtPlugin("com.lucidchart"           %   "sbt-scalafmt"                % "1.15")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -14,4 +14,4 @@ pomExtra := (
         <url>https://github.com/jacobwinch</url>
       </developer>
     </developers>
-  )
+)

--- a/src/main/scala/com/gu/tip/Configuration.scala
+++ b/src/main/scala/com/gu/tip/Configuration.scala
@@ -11,29 +11,46 @@ import scala.io.Source.fromFile
 
 // $COVERAGE-OFF$
 
-case class TipConfig(owner: String, repo: String, personalAccessToken: String, label: String)
+case class TipConfig(owner: String,
+                     repo: String,
+                     personalAccessToken: String,
+                     label: String)
 
-class TipConfigurationException(msg: String = "Missing TiP config. Please refer to README.") extends RuntimeException(msg)
-class MissingPathConfigurationFile(msg: String = "Missing tip.yaml. Please refer to README") extends RuntimeException(msg)
-class PathConfigurationSyntaxError(msg: String = "Bad syntax in tip.yaml. Please refer to README") extends RuntimeException(msg)
+class TipConfigurationException(
+    msg: String = "Missing TiP config. Please refer to README.")
+    extends RuntimeException(msg)
+class MissingPathConfigurationFile(
+    msg: String = "Missing tip.yaml. Please refer to README")
+    extends RuntimeException(msg)
+class PathConfigurationSyntaxError(
+    msg: String = "Bad syntax in tip.yaml. Please refer to README")
+    extends RuntimeException(msg)
 
 object Configuration {
-  object TipYamlProtocol extends DefaultYamlProtocol { implicit val pathFormat = yamlFormat2(Path) }
+  object TipYamlProtocol extends DefaultYamlProtocol {
+    implicit val pathFormat = yamlFormat2(Path)
+  }
 
   import TipYamlProtocol._
 
   val config: Config = ConfigFactory.load()
-  val tipConfig = config.as[Option[TipConfig]]("tip").getOrElse(throw new TipConfigurationException)
+  val tipConfig = config
+    .as[Option[TipConfig]]("tip")
+    .getOrElse(throw new TipConfigurationException)
 
   def readFile(filename: String): String =
-    Option(getClass.getClassLoader.getResource(filename)).map {
-      path => fromFile(path.getPath).mkString
-    }.getOrElse(throw new FileNotFoundException(s"Path definition file not found on the classpath: $filename"))
+    Option(getClass.getClassLoader.getResource(filename))
+      .map { path =>
+        fromFile(path.getPath).mkString
+      }
+      .getOrElse(throw new FileNotFoundException(
+        s"Path definition file not found on the classpath: $filename"))
 
-  def readPaths(filename: String): List[Path] = Try(readFile(filename).parseYaml.convertTo[List[Path]]).recover {
-    case e: FileNotFoundException => throw new MissingPathConfigurationFile
-    case _ => throw new PathConfigurationSyntaxError
-  }.get
+  def readPaths(filename: String): List[Path] =
+    Try(readFile(filename).parseYaml.convertTo[List[Path]]).recover {
+      case e: FileNotFoundException => throw new MissingPathConfigurationFile
+      case _                        => throw new PathConfigurationSyntaxError
+    }.get
 }
 
 // $COVERAGE-ON$

--- a/src/main/scala/com/gu/tip/GitHubApi.scala
+++ b/src/main/scala/com/gu/tip/GitHubApi.scala
@@ -24,15 +24,22 @@ trait GitHubApi extends GitHubApiIf with LazyLogging { this: HttpClientIf =>
       "Merge pull request #118 from ${owner}/hackday-2017-tip-test-1"
 
     So we try to pick out pull request number #118
-  */
+   */
   override def getLastMergeCommitMessage: WriterT[IO, List[Log], String] =
-    get(s"$githubApiRoot/repos/$owner/$repo/commits/master", authHeader).map(
-      response => (parse(response) \ "commit" \ "message").extract[String]
-    ).tell(List(Log("INFO", s"Successfully retrieved commit message of last merged PR")))
+    get(s"$githubApiRoot/repos/$owner/$repo/commits/master", authHeader)
+      .map(
+        response => (parse(response) \ "commit" \ "message").extract[String]
+      )
+      .tell(
+        List(Log("INFO",
+                 s"Successfully retrieved commit message of last merged PR")))
 
   override def setLabel(prNumber: String): WriterT[IO, List[Log], String] =
-    post(s"$githubApiRoot/repos/$owner/$repo/issues/$prNumber/labels", authHeader, s"""["$label"]""")
-      .tell(List(Log("INFO", s"Successfully set label '$label' on PR $prNumber")))
+    post(s"$githubApiRoot/repos/$owner/$repo/issues/$prNumber/labels",
+         authHeader,
+         s"""["$label"]""")
+      .tell(
+        List(Log("INFO", s"Successfully set label '$label' on PR $prNumber")))
 
   private lazy val authHeader = "Authorization" -> s"token $personalAccessToken"
 }

--- a/src/main/scala/com/gu/tip/HttpClient.scala
+++ b/src/main/scala/com/gu/tip/HttpClient.scala
@@ -8,12 +8,17 @@ import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.io._
 
 trait HttpClientIf {
-  def get(endpoint: String, authHeader: (String, String)): WriterT[IO, List[Log], String]
-  def post(endpoint: String, authHeader: (String, String), jsonBody: String): WriterT[IO, List[Log], String]
+  def get(endpoint: String,
+          authHeader: (String, String)): WriterT[IO, List[Log], String]
+  def post(endpoint: String,
+           authHeader: (String, String),
+           jsonBody: String): WriterT[IO, List[Log], String]
 }
 
 trait HttpClient extends HttpClientIf with Http4sClientDsl[IO] {
-  override def get(endpoint: String, authHeader: (String, String)): WriterT[IO, List[Log], String] = {
+  override def get(
+      endpoint: String,
+      authHeader: (String, String)): WriterT[IO, List[Log], String] = {
     val request = Request[IO](
       uri = Uri.unsafeFromString(endpoint),
       headers = Headers(Header(authHeader._1, authHeader._2)),
@@ -23,20 +28,27 @@ trait HttpClient extends HttpClientIf with Http4sClientDsl[IO] {
     WriterT(
       client.expect[String](request).map { response =>
         (
-          List(Log("INFO", s"Successfully executed HTTP GET request to $endpoint")),
+          List(
+            Log("INFO",
+                s"Successfully executed HTTP GET request to $endpoint")),
           response
         )
       }
     )
   }
 
-  override def post(endpoint: String, authHeader: (String, String), jsonBody: String): WriterT[IO, List[Log], String] = {
-    val request = POST(Uri.unsafeFromString(endpoint), jsonBody).putHeaders(Header(authHeader._1, authHeader._2))
+  override def post(endpoint: String,
+                    authHeader: (String, String),
+                    jsonBody: String): WriterT[IO, List[Log], String] = {
+    val request = POST(Uri.unsafeFromString(endpoint), jsonBody)
+      .putHeaders(Header(authHeader._1, authHeader._2))
 
     WriterT(
       client.expect[String](request).map { response =>
         (
-          List(Log("INFO", s"Successfully executed HTTP POST request to $endpoint")),
+          List(
+            Log("INFO",
+                s"Successfully executed HTTP POST request to $endpoint")),
           response
         )
       }

--- a/src/main/scala/com/gu/tip/Log.scala
+++ b/src/main/scala/com/gu/tip/Log.scala
@@ -1,13 +1,3 @@
 package com.gu.tip
 
-import cats.Semigroup
-
 case class Log(level: String, message: String)
-
-//object Log {
-//  implicit val logSemigroup: Semigroup[Log] = new Semigroup[Log] {
-//    def combine(x: Log, y: Log): Log = Log(x.level + "," + y.level, x.message + "," + y.message)
-//  }
-//}
-
-

--- a/src/main/scala/com/gu/tip/Notifier.scala
+++ b/src/main/scala/com/gu/tip/Notifier.scala
@@ -12,7 +12,7 @@ trait NotifierIf { this: GitHubApiIf =>
 trait Notifier extends NotifierIf with LazyLogging { this: GitHubApiIf =>
   def setLabelOnLatestMergedPr(): WriterT[IO, List[Log], String] =
     for {
-      prNumber <- getLastMergedPullRequestNumber()
+      prNumber     <- getLastMergedPullRequestNumber()
       responseBody <- setGitHubLabel(prNumber)
     } yield {
       responseBody
@@ -23,14 +23,19 @@ trait Notifier extends NotifierIf with LazyLogging { this: GitHubApiIf =>
       "Merge pull request #118 from ${owner}/hackday-2017-tip-test-1"
 
     So we try to pick out pull request number #118
-  */
+   */
   private def getLastMergedPullRequestNumber(): WriterT[IO, List[Log], String] =
-    getLastMergeCommitMessage.map { commitMessage =>
-      val prNumberPattern = """#\d+""".r
-      val prNumber = prNumberPattern.findFirstIn(commitMessage).get.tail // Using get() because currently we just swallow any exception in Tip.verify()
-      prNumber
-    }.tell(List(Log("INFO", s"Successfully extracted PR number from the commit message of the last merged PR")))
+    getLastMergeCommitMessage
+      .map { commitMessage =>
+        val prNumberPattern = """#\d+""".r
+        val prNumber        = prNumberPattern.findFirstIn(commitMessage).get.tail // Using get() because currently we just swallow any exception in Tip.verify()
+        prNumber
+      }
+      .tell(List(Log(
+        "INFO",
+        s"Successfully extracted PR number from the commit message of the last merged PR")))
 
   private def setGitHubLabel(prNumber: String): WriterT[IO, List[Log], String] =
-    setLabel(prNumber).tell(List(Log("INFO", s"Successfully set verification label on PR $prNumber")))
+    setLabel(prNumber).tell(
+      List(Log("INFO", s"Successfully set verification label on PR $prNumber")))
 }

--- a/src/main/scala/com/gu/tip/Tip.scala
+++ b/src/main/scala/com/gu/tip/Tip.scala
@@ -15,28 +15,30 @@ case object TipFinished                               extends TipResponse
 case class PathsActorResponse(msg: PathsActorMessage) extends TipResponse
 
 // NOK
-case object FailedToSetLabel                          extends TipResponse
-case class PathNotFound(name: String)                 extends TipResponse
-case object UnclassifiedError                         extends TipResponse
+case object FailedToSetLabel          extends TipResponse
+case class PathNotFound(name: String) extends TipResponse
+case object UnclassifiedError         extends TipResponse
 
 trait TipIf { this: NotifierIf =>
   def verify(pathName: String): Future[TipResponse]
 
   val pathConfigFilename = "tip.yaml"
 
-  implicit val system = ActorSystem()
-  implicit val ec = system.dispatcher
-  implicit val timeout = Timeout(10.second)
+  implicit val system           = ActorSystem()
+  implicit val ec               = system.dispatcher
+  implicit val timeout          = Timeout(10.second)
   lazy val pathsActor: ActorRef = PathsActor(pathConfigFilename)
 }
 
 trait Tip extends TipIf with LazyLogging { this: NotifierIf =>
-  system.registerOnTermination(logger.info("Successfully terminated actor system"))
+  system.registerOnTermination(
+    logger.info("Successfully terminated actor system"))
 
   def verify(pathName: String): Future[TipResponse] = {
-      pathsActor ? Verify(pathName) map {
-        case AllPathsVerified =>
-          setLabelOnLatestMergedPr.run.attempt.map({
+    pathsActor ? Verify(pathName) map {
+      case AllPathsVerified =>
+        setLabelOnLatestMergedPr.run.attempt
+          .map({
             case Left(error) =>
               logger.error("Failed to set label on PR!", error)
               FailedToSetLabel
@@ -46,25 +48,26 @@ trait Tip extends TipIf with LazyLogging { this: NotifierIf =>
               logger.info("Successfully verified all paths!")
               pathsActor ? Stop
               LabelSet
-          }).unsafeRunSync()
+          })
+          .unsafeRunSync()
 
-        case PathDoesNotExist(pathname)  =>
-          logger.error(s"Unrecognized path name: $pathname")
-          PathNotFound(pathname)
+      case PathDoesNotExist(pathname) =>
+        logger.error(s"Unrecognized path name: $pathname")
+        PathNotFound(pathname)
 
-        case response: PathsActorMessage =>
-          logger.trace(s"Tip received response from PathsActor: $response")
-          PathsActorResponse(response)
+      case response: PathsActorMessage =>
+        logger.trace(s"Tip received response from PathsActor: $response")
+        PathsActorResponse(response)
 
-      } recover {
-        case e: AskTimeoutException if (e.getMessage.contains("terminated")) => TipFinished
+    } recover {
+      case e: AskTimeoutException if (e.getMessage.contains("terminated")) =>
+        TipFinished
 
-        case e =>
-          logger.error(s"Unclassified Tip error: ", e)
-          UnclassifiedError
-      }
+      case e =>
+        logger.error(s"Unclassified Tip error: ", e)
+        UnclassifiedError
     }
+  }
 }
 
 object Tip extends Tip with Notifier with GitHubApi with HttpClient
-

--- a/src/test/scala/com/gu/tip/HttpClientTest.scala
+++ b/src/test/scala/com/gu/tip/HttpClientTest.scala
@@ -9,16 +9,25 @@ class HttpClientTest extends FlatSpec with MustMatchers {
   behavior of "HttpClient"
 
   it should "be able to make a GET request" in {
-    HttpClient.get("http://example.com", ("Authorization","test"))
-      .run.attempt.map(_.fold(error => fail, _ => succeed)).unsafeRunSync()
+    HttpClient
+      .get("http://example.com", ("Authorization", "test"))
+      .run
+      .attempt
+      .map(_.fold(error => fail, _ => succeed))
+      .unsafeRunSync()
   }
 
   it should "be able to make a POST request" in {
-    HttpClient.post(
-      "https://duckduckgo.com",
-      ("",""),
-      "test body"
-    ).run.attempt.map(_.fold(error => fail, _ => succeed)).unsafeRunSync()
+    HttpClient
+      .post(
+        "https://duckduckgo.com",
+        ("", ""),
+        "test body"
+      )
+      .run
+      .attempt
+      .map(_.fold(error => fail, _ => succeed))
+      .unsafeRunSync()
   }
 
 }

--- a/src/test/scala/com/gu/tip/PathsActorTest.scala
+++ b/src/test/scala/com/gu/tip/PathsActorTest.scala
@@ -9,36 +9,41 @@ import akka.util.Timeout
 class PathsActorTest extends AsyncFlatSpec with Matchers {
 
   private implicit val system = ActorSystem("HelloWorld")
-  implicit val ec = system.dispatcher
-  implicit val timeout = Timeout(10.second)
+  implicit val ec             = system.dispatcher
+  implicit val timeout        = Timeout(10.second)
 
   behavior of "PathsActor factory"
 
   it should "convert tip.yaml definition to Paths type" in {
-    PathsActor("tip.yaml") shouldBe a [ActorRef]
+    PathsActor("tip.yaml") shouldBe a[ActorRef]
   }
 
   it should "read correct number of paths from tip.yaml" in {
-    PathsActor("tip.yaml") ? NumberOfPaths map { _ shouldBe NumberOfPathsAnswer(2) }
+    PathsActor("tip.yaml") ? NumberOfPaths map {
+      _ shouldBe NumberOfPathsAnswer(2)
+    }
   }
 
   it should "throw exception if tip.yaml does not exist" in {
-      assertThrows[MissingPathConfigurationFile](PathsActor("tipppp.yaml"))
+    assertThrows[MissingPathConfigurationFile](PathsActor("tipppp.yaml"))
   }
 
   it should "throw exception if tip.yaml has bad syntax" in {
     assertThrows[PathConfigurationSyntaxError](PathsActor("tip-bad.yaml"))
   }
 
-
   behavior of "PathsActor"
 
   it should "have no verified paths initially" in {
-    PathsActor("tip.yaml") ? NumberOfVerifiedPaths map { _ shouldBe NumberOfVerifiedPathsAnswer(0) }
+    PathsActor("tip.yaml") ? NumberOfVerifiedPaths map {
+      _ shouldBe NumberOfVerifiedPathsAnswer(0)
+    }
   }
 
   it should "verify an existing path" in {
-    PathsActor("tip.yaml") ? Verify("Name A") map { _ shouldBe PathIsVerified("Name A")}
+    PathsActor("tip.yaml") ? Verify("Name A") map {
+      _ shouldBe PathIsVerified("Name A")
+    }
   }
 
   it should "verify an existing path only once" in {
@@ -48,11 +53,13 @@ class PathsActorTest extends AsyncFlatSpec with Matchers {
     val pathA2 = paths ? Verify("Name A")
 
     for {
-      _ <- pathA1
+      _      <- pathA1
       result <- pathA2
     } yield { result shouldBe PathIsAlreadyVerified("Name A") }
 
-    PathsActor("tip.yaml") ? Verify("Name A") map { _ shouldBe PathIsVerified("Name A")}
+    PathsActor("tip.yaml") ? Verify("Name A") map {
+      _ shouldBe PathIsVerified("Name A")
+    }
   }
 
   it should "indicate when all paths are verified" in {
@@ -62,14 +69,14 @@ class PathsActorTest extends AsyncFlatSpec with Matchers {
     val pathB = paths ? Verify("Name B")
 
     for {
-      _ <- pathA
+      _      <- pathA
       result <- pathB
-    } yield {result shouldBe AllPathsVerified}
+    } yield { result shouldBe AllPathsVerified }
   }
 
   it should "respond with PathDoesNotExist message when it cannot find the path" in {
-      PathsActor("tip.yaml") ? Verify("Misspelled Path Name") map {
-        _ shouldBe PathDoesNotExist("Misspelled Path Name")
-      }
+    PathsActor("tip.yaml") ? Verify("Misspelled Path Name") map {
+      _ shouldBe PathDoesNotExist("Misspelled Path Name")
+    }
   }
 }

--- a/src/test/scala/com/gu/tip/TipTest.scala
+++ b/src/test/scala/com/gu/tip/TipTest.scala
@@ -14,15 +14,18 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     WriterT(
       IO(
         (
-          List(Log("","")),
+          List(Log("", "")),
           ""
         )
       )
     )
 
   trait MockHttpClient extends HttpClient {
-    override def get(endpoint: String = "", authHeader: (String, String) = ("", "")) = mockOkResponse
-    override def post(endpoint: String = "", authHeader: (String, String) = ("", ""), jsonBody: String = "") = mockOkResponse
+    override def get(endpoint: String = "",
+                     authHeader: (String, String) = ("", "")) = mockOkResponse
+    override def post(endpoint: String = "",
+                      authHeader: (String, String) = ("", ""),
+                      jsonBody: String = "") = mockOkResponse
   }
 
   object Tip extends Tip with Notifier with GitHubApi with MockHttpClient
@@ -32,7 +35,7 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
   it should "throw an exception on missing TiP configuration"
 
   it should "throw an exception on bad syntax in path definition file" in {
-    object Tip extends Tip with Notifier with GitHubApi with MockHttpClient  {
+    object Tip extends Tip with Notifier with GitHubApi with MockHttpClient {
       override val pathConfigFilename: String = "tip-bad.yaml"
     }
 
@@ -40,7 +43,7 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
   }
 
   it should "throw an exception on missing path definition file" in {
-    object Tip extends Tip with Notifier with GitHubApi with MockHttpClient  {
+    object Tip extends Tip with Notifier with GitHubApi with MockHttpClient {
       override val pathConfigFilename: String = "tip-not-found.yaml"
     }
     assertThrows[MissingPathConfigurationFile](Tip.verify(""))
@@ -53,13 +56,15 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
   it should "handle exceptions thrown from Notifier" in {
     trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] =
-        WriterT(IO.raiseError(throw new RuntimeException).map(_ => (List(Log("", "")), "")))
+        WriterT(
+          IO.raiseError(throw new RuntimeException)
+            .map(_ => (List(Log("", "")), "")))
     }
 
     object Tip extends Tip with MockNotifier with GitHubApi with MockHttpClient
 
     for {
-      _ <- Tip.verify("Name A")
+      _      <- Tip.verify("Name A")
       result <- Tip.verify("Name B")
     } yield result mustBe UnclassifiedError
   }
@@ -67,38 +72,42 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
   it should "handle failure to set the label" in {
     trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] =
-        WriterT(IO.raiseError(UnexpectedStatus(InternalServerError)).map(_ => (List(Log("", "")), "")))
+        WriterT(
+          IO.raiseError(UnexpectedStatus(InternalServerError))
+            .map(_ => (List(Log("", "")), "")))
     }
 
     object Tip extends Tip with MockNotifier with GitHubApi with MockHttpClient
 
     for {
-     _ <- Tip.verify("Name A")
-     result <- Tip.verify("Name B")
+      _      <- Tip.verify("Name A")
+      result <- Tip.verify("Name B")
     } yield result mustBe FailedToSetLabel
   }
 
   behavior of "happy Tip"
 
   it should "verify a path" in {
-    Tip.verify("Name A").map(_ mustBe PathsActorResponse(PathIsVerified("Name A")))
+    Tip
+      .verify("Name A")
+      .map(_ mustBe PathsActorResponse(PathIsVerified("Name A")))
   }
 
   it should "set the label when all paths are verified" in {
-    trait MockNotifier extends NotifierIf {this: GitHubApiIf =>
+    trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr() = mockOkResponse
     }
 
     object Tip extends Tip with MockNotifier with GitHubApi with MockHttpClient
 
     for {
-      _ <- Tip.verify("Name A")
+      _      <- Tip.verify("Name A")
       result <- Tip.verify("Name B")
     } yield result mustBe LabelSet
   }
 
   it should "not set the label if the same path is verified multiple times concurrently (no race conditions)" in {
-    trait MockNotifier extends NotifierIf {this: GitHubApiIf =>
+    trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr = mockOkResponse
     }
 
@@ -110,16 +119,17 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     val path4 = Tip.verify("Name A")
 
     for {
-      _ <- path1
-      _ <- path2
-      _ <- path3
+      _      <- path1
+      _      <- path2
+      _      <- path3
       result <- path4
     } yield result must not be PathsActorResponse(AllPathsAlreadyVerified)
   }
 
   it should "shutdown its actor system after all paths have been verified" in {
-    trait MockNotifier extends NotifierIf {this: GitHubApiIf =>
-      override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] = mockOkResponse
+    trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
+      override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] =
+        mockOkResponse
     }
 
     object Tip extends Tip with MockNotifier with GitHubApi with MockHttpClient
@@ -132,11 +142,11 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     val path6 = Tip.verify("Name B")
 
     for {
-      _ <- Tip.verify("Name A") // execute these in sequence
-      _ <- Tip.verify("Name B")
-      _ <- Tip.verify("Name A")
-      _ <- Tip.verify("Name B")
-      _ <- Tip.verify("Name A")
+      _      <- Tip.verify("Name A") // execute these in sequence
+      _      <- Tip.verify("Name B")
+      _      <- Tip.verify("Name A")
+      _      <- Tip.verify("Name B")
+      _      <- Tip.verify("Name A")
       result <- Tip.verify("Name B")
     } yield result mustBe TipFinished
   }


### PR DESCRIPTION
Enforce [Scalafmt](http://scalameta.org/scalafmt/#Configuration) code formatter via [neo-sbt-scalafmt](https://github.com/lucidsoftware/neo-sbt-scalafmt).

```
> scalafmt       # format compile sources
> test:scalafmt  # format test sources
> sbt:scalafmt   # format .sbt source
```

