### PR TITLE
Add jvmopts to address java.lang.OutOfMemoryError: Metaspace

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,2 @@
+-Xmx1G 
+-XX:MaxMetaspaceSize=1G


### PR DESCRIPTION
```
Caused by: java.lang.OutOfMemoryError: Metaspace
```