### PR TITLE
Add get latest board endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ How to verify the most important user journeys are not broken without writing a 
       description: User completes account registration journey
     ```
 1. Put `tip.verify("My Path Name"")` statement at the point on the path where you consider path has been successfully completed.
-1. Visit `https://<tip cloud domain>/board/{sha}` to monitor verification in real-time.
+1. Visit `https://<tip cloud domain>/{owner}/{repo}/boards/head` to monitor verification in real-time.
 1. Example Tip configuration, which uses [`sbt-buildinfo`](https://github.com/sbt/sbt-buildinfo) to set `boardSha`:
     ```scala
       @Provides

--- a/cloud/deploy.sh
+++ b/cloud/deploy.sh
@@ -18,6 +18,7 @@ aws s3 cp $S3_KEY "s3://${S3_BUCKET}/"
 echo "Updating Lambda code"
 aws lambda update-function-code --function-name tip-create-board --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 aws lambda update-function-code --function-name tip-get-board --s3-bucket $S3_BUCKET --s3-key $S3_KEY
+aws lambda update-function-code --function-name tip-get-head-board --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 aws lambda update-function-code --function-name tip-verify-path --s3-bucket $S3_BUCKET --s3-key $S3_KEY
 
 echo "Done."

--- a/cloud/tip-cloud.yaml
+++ b/cloud/tip-cloud.yaml
@@ -94,6 +94,72 @@ Resources:
     - ApiBoardShaResource
     - tipGetBoardLambda
 
+  ApiOwnerResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref Api
+      ParentId: !GetAtt Api.RootResourceId
+      PathPart: '{owner}'
+    DependsOn: Api
+
+  ApiRepoResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref Api
+      ParentId: !Ref ApiOwnerResource
+      PathPart: '{repo}'
+    DependsOn:
+    - Api
+    - ApiOwnerResource
+
+  ApiBoardsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref Api
+      ParentId: !Ref ApiRepoResource
+      PathPart: boards
+    DependsOn:
+    - Api
+    - ApiOwnerResource
+    - ApiRepoResource
+
+  ApiHeadResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref Api
+      ParentId: !Ref ApiBoardsResource
+      PathPart: head
+    DependsOn:
+    - Api
+    - ApiOwnerResource
+    - ApiRepoResource
+    - ApiBoardsResource
+
+  ApiHeadMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ApiKeyRequired: false
+      AuthorizationType: NONE
+      RestApiId: !Ref Api
+      ResourceId: !Ref ApiHeadResource
+      HttpMethod: GET
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        IntegrationResponses:
+        - StatusCode: '200'
+        Uri: !Sub arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/${tipGetHeadBoardLambda.Arn}/invocations
+      MethodResponses:
+      - StatusCode: '200'
+        ResponseModels: { 'text/html': 'Empty' }
+    DependsOn:
+    - Api
+    - ApiOwnerResource
+    - ApiRepoResource
+    - ApiBoardsResource
+    - ApiHeadResource
+    - tipGetHeadBoardLambda
+
   AllowApiGatewayToInvokeCreateBoardLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -124,6 +190,16 @@ Resources:
     - tipGetBoardLambda
     - ApiBoardShaMethod
 
+  AllowApiGatewayToInvokeGetHeadBoardLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      FunctionName: !Sub arn:aws:lambda:eu-west-1:${AWS::AccountId}:function:tip-get-head-board
+    DependsOn:
+    - tipGetHeadBoardLambda
+    - ApiHeadMethod
+
   ApiDeployment:
     Type: AWS::ApiGateway::Deployment
     Properties:
@@ -138,6 +214,7 @@ Resources:
     - AllowApiGatewayToInvokeCreateBoardLambdaPermission
     - AllowApiGatewayToInvokeVerifyPathLambdaPermission
     - AllowApiGatewayToInvokeGetBoardLambdaPermission
+    - AllowApiGatewayToInvokeGetHeadBoardLambdaPermission
 
   # ****************************************************************************
   # Lambdas
@@ -162,6 +239,20 @@ Resources:
       FunctionName: tip-get-board
       Description: Get board
       Handler: "tip-get-board.handler"
+      Role: !Sub arn:aws:iam::${AWS::AccountId}:role/lambda-dynamodb-full-access-role
+      Code:
+        S3Bucket: identity-lambda
+        S3Key: tip-cloud.zip
+      Runtime: nodejs8.10
+      MemorySize: "128"
+      Timeout: "10"
+
+  tipGetHeadBoardLambda:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      FunctionName: tip-get-head-board
+      Description: Get repo's latest board
+      Handler: "tip-get-head-board.handler"
       Role: !Sub arn:aws:iam::${AWS::AccountId}:role/lambda-dynamodb-full-access-role
       Code:
         S3Bucket: identity-lambda

--- a/cloud/tip-get-head-board.js
+++ b/cloud/tip-get-head-board.js
@@ -1,0 +1,167 @@
+const AWS = require('aws-sdk');
+AWS.config.update({region: 'eu-west-1'});
+const ddb = new AWS.DynamoDB.DocumentClient();
+
+const getBoard = (repo) => {
+    return ddb.scan(
+        {
+            TableName: 'TipCloud-PROD',
+            FilterExpression : 'repo = :repo',
+            ExpressionAttributeValues : {':repo' : `${repo}`}
+        }
+    ).promise();
+}
+
+const getLatestBoard = (boards) =>
+    boards
+        .Items
+        .sort((a,b) => new Date(b.deployTime) - new Date(a.deployTime))[0];
+
+const renderBoard = (item) => {
+    return new Promise((resolve, reject) => {
+        const pathsWithStatusColour =
+            item.board
+                .map(path => {
+                    let colour;
+                    if (path.verified)
+                        colour = `style="background-color:green"`;
+                    else
+                        colour = `style="background-color:grey"`;
+
+                    return `<span ${colour}>${path.name}</span>`;
+                })
+                .toString()
+                .replace (/,/g, "");
+
+        const sha = item.sha;
+        const repo = item.repo;
+        const numberOfVerifiedPaths = item.board.filter( path => path.verified == true).length;
+        const coverage = Math.round((100 * numberOfVerifiedPaths) / item.board.length);
+        const deployTime = item.deployTime;
+        const elapsedTimeSinceDeploy = Date.now() - Date.parse(deployTime);
+
+        const linkToCommit = `https://github.com/${repo}/commit/${sha}`;
+
+        const html = `
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <meta http-equiv="refresh" content="5" >
+            
+            <style>
+            
+                body {
+                  background-color: whitesmoke;
+                  color:lightgrey;
+                  font-family: "Courier New", Courier, monospace
+                }
+                
+                span {
+                    display: inline-block;
+                    border: 1px solid;
+                    margin: 4px;
+                    height: 70px;
+                    width: 155px;
+                    text-align: center;
+                    vertical-align: middle;
+                    font-weight: bold;
+                    font-family: "Courier New", Courier, monospace;
+                }
+                
+                #myProgress {
+                    width: 100%;
+                    background-color: grey;
+                }
+                
+                #myBar {
+                    width: 79%;
+                    height: 30px;
+                    background-color: green;
+                }
+                
+                .barcontainer {
+                  width: 100%;
+                  background-color: #ddd;
+                }
+                
+                .progressbar {
+                  text-align: right;
+                  line-height: 30px;
+                  color: white;
+                }
+                
+                .coverageprogress {width: ${coverage}%; background-color: #4CAF50;}
+                
+                a {
+                  color: lightgrey;
+                }
+                
+                #container{
+                  max-width: 990px;
+                  margin: auto;
+                  background: #282828;
+                  padding: 10px;
+                }
+                
+            
+            </style>
+            </head>
+            
+            <body>
+            
+            <div id="container">
+                <h3>
+                <a href="${linkToCommit}">${repo} ${sha}</a>
+                </h3>
+                
+                <hr>
+                
+                <p>
+                Elapsed time since deploy: <time>${msToTime(elapsedTimeSinceDeploy)}</time> 
+                </p>
+                
+                <div class="barcontainer">
+                  <div class="progressbar coverageprogress">${coverage}%</div>
+                </div>
+                
+                <br>
+                
+                ${pathsWithStatusColour}
+            </div>
+            </body>
+            </html>
+          `;
+
+        const response = {
+            statusCode: 200,
+            headers: {
+                'Content-Type': 'text/html',
+            },
+            body: html,
+        };
+
+        resolve(response);
+    });
+}
+
+const msToTime = (s) => {
+    var ms = s % 1000;
+    s = (s - ms) / 1000;
+    var secs = s % 60;
+    s = (s - secs) / 60;
+    var mins = s % 60;
+    var hrs = (s - mins) / 60;
+
+    return hrs + ':' + mins + ':' + secs;
+}
+
+exports.handler = (event, context, callback) => {
+    const owner = event.pathParameters.owner;
+    const repo = event.pathParameters.repo;
+    const slug = `${owner}/${repo}`;
+
+    getBoard(slug)
+        .then(boards => getLatestBoard(boards))
+        .then(latestBoard => renderBoard(latestBoard))
+        .then(boardAsHtml => callback(null, boardAsHtml));
+};

--- a/src/main/scala/com/gu/tip/cloud/TipCloudApi.scala
+++ b/src/main/scala/com/gu/tip/cloud/TipCloudApi.scala
@@ -19,7 +19,7 @@ trait TipCloudApi extends TipCloudApiIf with LazyLogging {
   this: HttpClientIf with ConfigurationIf =>
 
   val tipCloudApiRoot =
-    "https://xg4oy7zx9b.execute-api.eu-west-1.amazonaws.com/PROD"
+    "https://i2i2l4x9kl.execute-api.eu-west-1.amazonaws.com/PROD"
 
   override def createBoard(
       sha: String,


### PR DESCRIPTION
* `/{owner}/{repo}/boards/head`, for example, `/guardian/identity/boards/head`
* Users no longer have to get the commit SHA and can simply bookmark the above link to get the latest board
