### PR TITLE
Make Github label setting optional and fire-and-forget

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ How to verify the most important user journeys are not broken without writing a 
         val tipConfig = TipConfig(
           owner = "guardian",
           repo = "identity",
-          personalAccessToken = config.Tip.personalAccessToken, // set to empty string "" if you do not need GitHub label functionality
-          label = "Verified in PROD",
+          personalAccessToken = config.Tip.personalAccessToken, // remove if you do not need GitHub label functionality
+          label = "Verified in PROD", // remove if you do not need GitHub label functionality
           boardSha = BuildInfo.GitHeadSha
         )
     

--- a/src/main/scala/com/gu/tip/Configuration.scala
+++ b/src/main/scala/com/gu/tip/Configuration.scala
@@ -14,8 +14,8 @@ import scala.io.Source
 
 case class TipConfig(owner: String,
                      repo: String,
-                     personalAccessToken: String,
-                     label: String,
+                     personalAccessToken: String = "",
+                     label: String = "",
                      boardSha: String = "")
 
 class TipConfigurationException(

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 tip {
   owner = "mario-galic"
   repo = "sandbox"
-  personalAccessToken = ""
+  personalAccessToken = "testtoken"
   label = "Verified in PROD"
 }

--- a/src/test/scala/com/gu/tip/TipTest.scala
+++ b/src/test/scala/com/gu/tip/TipTest.scala
@@ -95,7 +95,7 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     } yield result mustBe UnclassifiedError
   }
 
-  it should "handle failure to set the label" in {
+  it should "not affect verification result when setting of PR label fails" in {
     trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] =
         WriterT(
@@ -114,7 +114,7 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     for {
       _      <- Tip.verify("Name A")
       result <- Tip.verify("Name B")
-    } yield result mustBe FailedToSetLabel
+    } yield result mustBe AllTestsInProductionPassed
   }
 
   behavior of "happy Tip"
@@ -125,7 +125,7 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
       .map(_ mustBe PathsActorResponse(PathIsVerified("Name A")))
   }
 
-  it should "set the label when all paths are verified" in {
+  it should "return AllTestsInProductionPassed when all paths have been verified" in {
     trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr(): WriterT[IO, List[Log], String] =
         mockOkResponse
@@ -142,10 +142,10 @@ class TipTest extends AsyncFlatSpec with MustMatchers {
     for {
       _      <- Tip.verify("Name A")
       result <- Tip.verify("Name B")
-    } yield result mustBe LabelSet
+    } yield result mustBe AllTestsInProductionPassed
   }
 
-  it should "not set the label if the same path is verified multiple times concurrently (no race conditions)" in {
+  it should "not return AllTestsInProductionPassed if the same path is verified multiple times concurrently (no race conditions)" in {
     trait MockNotifier extends NotifierIf { this: GitHubApiIf =>
       override def setLabelOnLatestMergedPr: WriterT[IO, List[Log], String] =
         mockOkResponse


### PR DESCRIPTION
Config can now be just

```
TipConfig(
  owner = "guardian",
  repo = "identity",
  boardSha = BuildInfo.GitHeadSha
)
```