### PR TITLE
Update TiP Cloud URL and enforce usage of an API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ and a message is written to logs `All tests in production passed.`
     ```
     libraryDependencies += "com.gu" %% "tip" % "0.5.0"
     ```
+1. Obtain an API Key for TiP Cloud (contact the contributors to this project).    
+1. Add the TiP Cloud API Key to your private configuration  
 1. List paths to be covered in `tip.yaml` file and make sure it is on the classpath:
     ```
     - name: Register
@@ -24,14 +26,14 @@ and a message is written to logs `All tests in production passed.`
 
     - name: Update User
       description: User changes account details
-    ```
+    ``` 
 1. Instantiate `Tip` with `TipConfig`: 
     ```scala
-    val tipConfig = TipConfig("guardian/identity")
+    val tipConfig = TipConfig(repo = "guardian/identity", cloudSecret = "my_secret")
     TipFactory.create(tipConfig)
     ```
 1. Call `tip.verify("My Path Name"")` at the point where you consider path has been successfully completed.
-1. Access board at `<tip cloud domain>/{owner}/{repo}/boards/head` to monitor verification in real-time.
+1. Access board at `<tip cloud domain>/{owner}/{repo}/boards/head` (using your API key) to monitor verification in real-time.
     
 ### Setting a label on PR
 Optionally, if you want Tip to notify when all paths have been hit by setting a label on the corresponding merged PR, then  
@@ -41,6 +43,7 @@ Optionally, if you want Tip to notify when all paths have been hit by setting a 
 1. Set `personalAccessToken` in `TipConfig`:
     ```scala
     TipConfig(
+      cloudSecret = "my_secret" // remove and set cloudEnabled=false if you only need GitHub label functionality
       repo = "guardian/identity",
       personalAccessToken = some-secret-token
     )
@@ -59,6 +62,7 @@ Optionally, if you want to have a separate board for each merged PR, then
      ```scala
      TipConfig(
        repo = "guardian/identity",
+       cloudSecret = "my_secret" 
        personalAccessToken = config.Tip.personalAccessToken, // remove if you do not need GitHub label functionality
        label = "Verified in PROD", // remove if you do not need GitHub label functionality
        boardSha = BuildInfo.GitHeadSha // remove if you need only one board instead of board per sha

--- a/cloud/tip-cloud.yaml
+++ b/cloud/tip-cloud.yaml
@@ -34,10 +34,43 @@ Resources:
       PathPart: board
     DependsOn: Api
 
+  # Can be shared by all clients
+  TipUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    Properties:
+      UsagePlanName: tip-usage-plan
+      ApiStages:
+      - ApiId: !Ref Api
+        Stage: PROD
+    DependsOn:
+    - Api
+
+  TipReaderRevenueApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: Used by Reader Revenue teams
+      Enabled: true
+      Name: !Sub tip-api-key-reader-revenue
+      StageKeys:
+        - RestApiId: !Ref Api
+          StageName: PROD
+    DependsOn:
+    - Api
+
+  TipReaderRevenueUsagePlanKey:
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !Ref TipReaderRevenueApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref TipUsagePlan
+    DependsOn:
+    - TipReaderRevenueApiKey
+    - TipUsagePlan
+
   ApiBoardMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      ApiKeyRequired: false
+      ApiKeyRequired: true
       AuthorizationType: NONE
       RestApiId: !Ref Api
       ResourceId: !Ref ApiBoardResource
@@ -64,7 +97,7 @@ Resources:
   ApiBoardPathMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      ApiKeyRequired: false
+      ApiKeyRequired: true
       AuthorizationType: NONE
       RestApiId: !Ref Api
       ResourceId: !Ref ApiBoardPathResource
@@ -91,7 +124,7 @@ Resources:
   ApiBoardShaMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      ApiKeyRequired: false
+      ApiKeyRequired: true
       AuthorizationType: NONE
       RestApiId: !Ref Api
       ResourceId: !Ref ApiBoardShaResource
@@ -154,7 +187,7 @@ Resources:
   ApiHeadMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      ApiKeyRequired: false
+      ApiKeyRequired: true
       AuthorizationType: NONE
       RestApiId: !Ref Api
       ResourceId: !Ref ApiHeadResource
@@ -192,7 +225,7 @@ Resources:
   ApiHeadPathsMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      ApiKeyRequired: false
+      ApiKeyRequired: true
       AuthorizationType: NONE
       RestApiId: !Ref Api
       ResourceId: !Ref ApiHeadPathsResource

--- a/src/main/scala/com/gu/tip/Configuration.scala
+++ b/src/main/scala/com/gu/tip/Configuration.scala
@@ -13,6 +13,7 @@ import scala.io.Source
 // $COVERAGE-OFF$
 case class TipConfig(repo: String,
                      cloudEnabled: Boolean = true,
+                     cloudSecret: String = "",
                      boardSha: String = "",
                      personalAccessToken: String = "",
                      label: String = "")

--- a/src/main/scala/com/gu/tip/cloud/TipCloudApi.scala
+++ b/src/main/scala/com/gu/tip/cloud/TipCloudApi.scala
@@ -17,8 +17,7 @@ trait TipCloudApiIf { this: HttpClientIf with ConfigurationIf =>
 trait TipCloudApi extends TipCloudApiIf with LazyLogging {
   this: HttpClientIf with ConfigurationIf =>
 
-  val tipCloudApiRoot =
-    "https://be9p0izsnc.execute-api.eu-west-1.amazonaws.com/PROD"
+  val tipCloudApiRoot = "https://tip.gutools.co.uk"
 
   override def createBoard(sha: String,
                            repo: String): WriterT[IO, List[Log], String] = {
@@ -90,5 +89,5 @@ trait TipCloudApi extends TipCloudApiIf with LazyLogging {
     createBoard(sha, repo).run.attempt.unsafeRunSync()
   }
 
-  private lazy val auth = "Authorization" -> "Hello world"
+  private lazy val auth = "x-api-key" -> configuration.tipConfig.cloudSecret
 }


### PR DESCRIPTION
* Configures TiP Cloud to use https://tip.gutools.co.uk.
* Adds requirement to authenticate (using an API key) in order to make HTTP requests to any TiP Cloud endpoint. Note that for the dashboard endpoints this is a temporary measure only - we will look to put Google Auth in front of these in a follow-up PR.
* Cloudforms an API key for Reader Revenue usage.

cc @mario-galic @michaelwmcnamara 