### PR TITLE
Add TipAssert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala: 2.12.6
 jdk:
-  - oraclejdk8
+  - openjdk8
 script: |
     sbt ++$TRAVIS_SCALA_VERSION clean coverage test
 after_success: sbt coverageReport coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import Dependencies._
 import sbtrelease.ReleaseStateTransformations._
 
 lazy val root = (project in file(".")).settings(
@@ -6,7 +5,7 @@ lazy val root = (project in file(".")).settings(
   description := "Scala library for testing in production.",
   organization := "com.gu",
   scalaVersion := "2.12.6",
-  libraryDependencies ++= dependencies,
+  libraryDependencies ++= Dependencies.all,
   sources in doc in Compile := List(),
   publishTo := Some(
     if (isSnapshot.value) { Opts.resolver.sonatypeSnapshots }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,8 @@ object Dependencies {
   val http4sVersion = "0.18.17"
   val akkaVersion = "2.5.8"
 
-  lazy val scalaTest =      "org.scalatest"               %%  "scalatest"           % "3.0.5"         % Test
+  lazy val test =       Seq("org.scalatest"               %%  "scalatest"           % "3.0.5"         % Test,
+                            "org.mockito"                 %   "mockito-core"        % "2.27.0"        % Test)
   lazy val scalaLogging =   "com.typesafe.scala-logging"  %%  "scala-logging"       % "3.8.0"
   lazy val listJson =       "net.liftweb"                 %%  "lift-json"           % "3.3.0"
   lazy val ficus =          "com.iheart"                  %%  "ficus"               % "1.4.3"
@@ -14,14 +15,18 @@ object Dependencies {
   lazy val http4s =     Seq("org.http4s"                  %%  "http4s-dsl"          % http4sVersion,
                             "org.http4s"                  %%  "http4s-blaze-client" % http4sVersion,
                             "org.http4s"                  %%  "http4s-circe"        % http4sVersion)
+  lazy val retry =      Seq("com.softwaremill.retry"      %% "retry"                % "0.3.2",
+                            "com.softwaremill.odelay"     %% "odelay-core"          % "0.3.0")
 
-  lazy val dependencies =
+  val all =
     Seq(
-      scalaTest,
       scalaLogging,
       listJson,
       ficus,
-      yaml)
+      yaml
+    )
     .++(http4s)
     .++(akka)
+    .++(retry)
+    .++(test)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaVersion = "2.5.8"
 
   lazy val test =       Seq("org.scalatest"               %%  "scalatest"           % "3.0.5"         % Test,
-                            "org.mockito"                 %   "mockito-core"        % "2.27.0"        % Test)
+                            "org.mockito"                 %%  "mockito-scala"       % "1.5.2"         % Test)
   lazy val scalaLogging =   "com.typesafe.scala-logging"  %%  "scala-logging"       % "3.8.0"
   lazy val listJson =       "net.liftweb"                 %%  "lift-json"           % "3.3.0"
   lazy val ficus =          "com.iheart"                  %%  "ficus"               % "1.4.3"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -54,11 +54,11 @@
  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
-<!-- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">-->
-<!--  <parameters>-->
-<!--   <parameter name="regex"><![CDATA[println]]></parameter>-->
-<!--  </parameters>-->
-<!-- </check>-->
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[println]]></parameter>
+  </parameters>
+ </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
    <parameter name="maxTypes"><![CDATA[30]]></parameter>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -54,11 +54,11 @@
  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[println]]></parameter>
-  </parameters>
- </check>
+<!-- <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">-->
+<!--  <parameters>-->
+<!--   <parameter name="regex"><![CDATA[println]]></parameter>-->
+<!--  </parameters>-->
+<!-- </check>-->
  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
   <parameters>
    <parameter name="maxTypes"><![CDATA[30]]></parameter>

--- a/src/main/scala/com/gu/tip/assertion/TipAssert.scala
+++ b/src/main/scala/com/gu/tip/assertion/TipAssert.scala
@@ -1,0 +1,52 @@
+package com.gu.tip.assertion
+
+import java.util.concurrent.Executors
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+
+import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Random, Success, Try}
+
+sealed trait AssertionResult
+case object TipAssertPass extends AssertionResult
+case object TipAssertFail extends AssertionResult
+
+trait TipAssertIf {
+  protected val logger: Logger
+
+  val threadPool = Executors.newFixedThreadPool(
+    2,
+    (r: Runnable) =>
+      new Thread(r, s"tip-assertion-pool-thread-${Random.nextInt(2)}"))
+  private val assertionExecutionContext =
+    ExecutionContext.fromExecutor(threadPool)
+
+  def apply[T](
+      f: => Future[T],
+      p: T => Boolean,
+      msg: String,
+      max: Int = 1,
+      delay: FiniteDuration = 0.seconds
+  ): Future[AssertionResult] = {
+
+    implicit val ec = assertionExecutionContext
+    retry.Pause(max, delay)(odelay.Timer.default) {
+      f.map { v =>
+        Try(assert(p(v)))
+      }
+    } map {
+      case Failure(_) =>
+        logger.error(msg)
+        TipAssertFail
+
+      case Success(_) =>
+        TipAssertPass
+    }
+
+  }
+
+}
+
+object TipAssert extends TipAssertIf with LazyLogging

--- a/src/main/scala/com/gu/tip/assertion/TipAssert.scala
+++ b/src/main/scala/com/gu/tip/assertion/TipAssert.scala
@@ -3,8 +3,8 @@ package com.gu.tip.assertion
 import java.util.concurrent.Executors
 
 import com.typesafe.scalalogging.{LazyLogging, Logger}
+import retry.Defaults
 
-import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Random, Success, Try}
@@ -19,7 +19,8 @@ trait TipAssertIf {
   val threadPool = Executors.newFixedThreadPool(
     2,
     (r: Runnable) =>
-      new Thread(r, s"tip-assertion-pool-thread-${Random.nextInt(2)}"))
+      new Thread(r, s"tip-assertion-pool-thread-${Random.nextInt(2)}")
+  )
   private val assertionExecutionContext =
     ExecutionContext.fromExecutor(threadPool)
 
@@ -28,7 +29,7 @@ trait TipAssertIf {
       p: T => Boolean,
       msg: String,
       max: Int = 1,
-      delay: FiniteDuration = 0.seconds
+      delay: FiniteDuration = Defaults.delay
   ): Future[AssertionResult] = {
 
     implicit val ec = assertionExecutionContext

--- a/src/test/scala/com/gu/tip/assertion/TipAssertTest.scala
+++ b/src/test/scala/com/gu/tip/assertion/TipAssertTest.scala
@@ -1,0 +1,48 @@
+package com.gu.tip.assertion
+
+import com.typesafe.scalalogging.Logger
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{AsyncFlatSpec, MustMatchers}
+import org.mockito.Mockito._
+import scala.concurrent.Future
+
+class TipAssertTest extends AsyncFlatSpec with MustMatchers with MockitoSugar {
+  "TipAssert" should "succeed" in {
+    val f = Future(1)
+    TipAssert(
+      f,
+      (v: Int) => v == 1,
+      "Duplicate DD mandates created! Fix ASAP!"
+    ) map (_ must be(TipAssertPass))
+  }
+
+  it should "fail" in {
+    val f = Future(3)
+    TipAssert(
+      f,
+      (v: Int) => v == 1,
+      "Duplicate DD mandates created! Fix ASAP!"
+    ) map (_ must be(TipAssertFail))
+  }
+
+  it should "log error on failed assertion" in {
+    val underlying = mock[org.slf4j.Logger]
+    when(underlying.isErrorEnabled()).thenReturn(true)
+    val loggerMock = Logger(underlying)
+
+    object TipAssertWithMockLogger extends TipAssertIf {
+      override val logger: Logger = loggerMock
+    }
+
+    val f = Future(3)
+    TipAssertWithMockLogger(
+      f,
+      (v: Int) => v == 1,
+      "User double-charged. Fix ASAP!"
+    ) map { result =>
+      verify(underlying).error("User double-charged. Fix ASAP!")
+      result must be(TipAssertFail)
+    }
+  }
+
+}

--- a/src/test/scala/com/gu/tip/assertion/TipAssertTest.scala
+++ b/src/test/scala/com/gu/tip/assertion/TipAssertTest.scala
@@ -1,12 +1,15 @@
 package com.gu.tip.assertion
 
 import com.typesafe.scalalogging.Logger
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.IdiomaticMockito
 import org.scalatest.{AsyncFlatSpec, MustMatchers}
-import org.mockito.Mockito._
 import scala.concurrent.Future
 
-class TipAssertTest extends AsyncFlatSpec with MustMatchers with MockitoSugar {
+class TipAssertTest
+    extends AsyncFlatSpec
+    with MustMatchers
+    with IdiomaticMockito {
+
   "TipAssert" should "succeed" in {
     val f = Future(1)
     TipAssert(
@@ -27,7 +30,7 @@ class TipAssertTest extends AsyncFlatSpec with MustMatchers with MockitoSugar {
 
   it should "log error on failed assertion" in {
     val underlying = mock[org.slf4j.Logger]
-    when(underlying.isErrorEnabled()).thenReturn(true)
+    underlying.isErrorEnabled() shouldReturn true
     val loggerMock = Logger(underlying)
 
     object TipAssertWithMockLogger extends TipAssertIf {
@@ -40,7 +43,7 @@ class TipAssertTest extends AsyncFlatSpec with MustMatchers with MockitoSugar {
       (v: Int) => v == 1,
       "User double-charged. Fix ASAP!"
     ) map { result =>
-      verify(underlying).error("User double-charged. Fix ASAP!")
+      underlying.error("User double-charged. Fix ASAP!") was called
       result must be(TipAssertFail)
     }
   }


### PR DESCRIPTION
### TipAssert

`TipAssert` runs an assertion on a pass-by-name value in a separate thread and simply logs an error on failed assertion. The idea is to have assertions run on production behaviour off the main thread which should not affect main business logic, whilst being used in combination with crash monitoring software (for example, Sentry) which can alert on `log.error` statement. 

Users should use a separate `ExecutionContext` dedicated just to assertions to make sure assertions are not starving main business logic thread pool:

```scala
import com.gu.tip.assertion.ExecutionContext.assertionExecutionContext
Future(/* request we will assert on */)(assertionExecutionContext)
```

_(Note Because `ExecutionContext` of a `Future` [cannot be changed](https://medium.com/@sderosiaux/are-scala-futures-the-past-69bd62b9c001#a10c) after `Future` definition, TiP cannot take care of this for the user.)_

For example, say we have a scenario where we take payments from user and want to make sure we have not double charged them. Given the following requests returning `Future`s

```scala
def chargeUser(implicit ec: ExecutionContext): Future[_]
def getNumberOfCharges(implicit ec: ExecutionContext): Future[Int]
```

then we could check if user has been double charged with
```scala
import com.gu.tip.assertion.TipAssert
import com.gu.tip.assertion.ExecutionContext.assertionExecutionContext

chargeUser(mainExecutionContext) andThen { case _ =>
  TipAssert(
    getNumberOfCharges(assertionExecutionContext),
    (num: Int) => num == 1,
    "User should be charged only once. Fix ASAP!"
  )
}
```
`TipAssert` can also handle eventually semantics via `max` and `delay` parameters for scenarios where database mutation is only eventually consistent. Here is the full signature:
 
 ```scala
def apply[T](
      f: => Future[T],
      p: T => Boolean,
      msg: String,
      max: Int = 1,
      delay: FiniteDuration = 0.seconds
  ): Future[AssertionResult] 
```

Note currently `TipAssert` is not related to `Tip.verify` functionality in any way. One major semantical  difference between the two is that `TipAssert` checks failed paths whilst `Tip.verify` checks successful paths. 

Related conversations

- https://github.com/guardian/support-frontend/pull/1797
- https://stackoverflow.com/questions/56194442/safety-of-running-assertions-in-a-separate-execution-context
