### PR TITLE
Update TipCloud lambdas to use Node 12

### DIFF
--- a/cloud/tip-cloud.yaml
+++ b/cloud/tip-cloud.yaml
@@ -345,7 +345,7 @@ Resources:
       Code:
         S3Bucket: !Ref s3Bucket
         S3Key: !Ref s3Key
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: "128"
       Timeout: "10"
 
@@ -359,7 +359,7 @@ Resources:
       Code:
         S3Bucket: !Ref s3Bucket
         S3Key: !Ref s3Key
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: "128"
       Timeout: "10"
 
@@ -373,7 +373,7 @@ Resources:
       Code:
         S3Bucket: !Ref s3Bucket
         S3Key: !Ref s3Key
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: "128"
       Timeout: "10"
 
@@ -387,7 +387,7 @@ Resources:
       Code:
         S3Bucket: !Ref s3Bucket
         S3Key: !Ref s3Key
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: "128"
       Timeout: "10"
 
@@ -401,7 +401,7 @@ Resources:
       Code:
         S3Bucket: !Ref s3Bucket
         S3Key: !Ref s3Key
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: "128"
       Timeout: "10"
 


### PR DESCRIPTION
As part of health work on Identity, as well as the fact that Node 8 lambdas are being deprecated by AWS, we're updating all Lambdas hosted on the Identity AWS account to use a newer LTS version (in this case Node 12). I noticed that TipCloud was being hosted on Identity, hence I'm creating this PR.

I've updated the CloudFormation to use the `node12.x` runtime, which is LTS, as Node (and JavaScript) is backwards compatible, an in place upgrade shouldn't cause any problems.