### PR TITLE
update to scala 2.13 and sbt 1.4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+.bsp
+.metals
 target/
 *.zip
 .DS_Store

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).settings(
   name := "tip",
   description := "Scala library for testing in production.",
   organization := "com.gu",
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.13.4",
   libraryDependencies ++= Dependencies.all,
   sources in doc in Compile := List(),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -26,8 +26,7 @@ lazy val root = (project in file(".")).settings(
   scalafmtTestOnCompile := true,
   scalafmtShowDiff := true,
   scalacOptions ++= Seq(
-    "-Ywarn-unused-import",
-    "-Ypartial-unification",
+    "-Ywarn-unused:imports",
     "-Yrangepos"
   ),
   addCompilerPlugin(scalafixSemanticdb)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ addSbtPlugin("org.scoverage"            %   "sbt-scoverage"               % "1.5
 addSbtPlugin("org.scoverage"            %   "sbt-coveralls"               % "1.2.2")
 addSbtPlugin("org.scalastyle"           %%  "scalastyle-sbt-plugin"       % "1.0.0")
 addSbtPlugin("com.lucidchart"           %   "sbt-scalafmt"                % "1.15")
-addSbtPlugin("ch.epfl.scala"            %%  "sbt-scalafix"                % "0.6.0-M12")
+addSbtPlugin("ch.epfl.scala"            %%  "sbt-scalafix"                % "0.9.24")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4-SNAPSHOT"
+version in ThisBuild := "0.6.4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4"
+version in ThisBuild := "0.6.5-SNAPSHOT"


### PR DESCRIPTION
This PR updates TIP to use scala 2.13

This is necessary to update support-frontend and others to scala 2.13 and retaining the TIP functionality.