### PR TITLE
Synk monitor GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: snyk monitor 
+on: push
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/scala@master
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        SNYK_ORG: ${{ secrets.SNYK_ORG }}
+      with:
+        args: --org=$SNYK_ORG --project-name=guardian/tip
+        command: monitor  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         SNYK_ORG: ${{ secrets.SNYK_ORG }}
       with:
-        args: --org=$SNYK_ORG --project-name=guardian/tip
+        args: --org=${env.SNYK_ORG} --project-name=guardian/tip
         command: monitor  

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,6 @@ jobs:
       uses: snyk/actions/scala@master
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        SNYK_ORG: ${{ secrets.SNYK_ORG }}
       with:
-        args: --org=${env.SNYK_ORG} --project-name=guardian/tip
+        args: --org=${{ secrets.SNYK_ORG }} --project-name=guardian/tip
         command: monitor  


### PR DESCRIPTION
This is an experiment to try running `synk monitor` via GitHub actions instead of TeamCity. This way we can build and synk in parallel.
